### PR TITLE
Support 2FA

### DIFF
--- a/PageProtector.module.php
+++ b/PageProtector.module.php
@@ -301,6 +301,9 @@ input[type='password'] {
                 $tfa = $user->hasTfa(true);
                 // get the actual Tfa instance we need
                 $this->wire('session')->loginFailed = !$tfa->start($username, $this->wire('input')->post->pass);
+                if ($this->wire('session')->loginFailed) {
+                    $this->wire('session')->redirect(htmlspecialchars($_SERVER['REQUEST_URI']));
+                }
                 //tfa login supercedes normal login function
             }
             else {


### PR DESCRIPTION
So, here's my initial draft of integrating 2FA support into PageProtector. So far it works. Embeds form when appropriate, doesn't render page if the 2FA couldn't start, etc. But I'm still a bit confused at how to check if a 2FA flow is active without loading the entire Tfa class instance before the user signs in (regardless if anonymous or not). I haven't figured out a way around that, which is why there's still usage of this snippet for the second of the 2FA phase.

```
$tfa = $this->wire('modules')->get('ProcessLogin')->getTfa();
```